### PR TITLE
Use HTTPS for Google Maps

### DIFF
--- a/js/google-map.js
+++ b/js/google-map.js
@@ -33,7 +33,7 @@ function init() {
     var addresses = ['Brooklyn'];
 
     for (var x = 0; x < addresses.length; x++) {
-        $.getJSON('http://maps.googleapis.com/maps/api/geocode/json?address='+addresses[x]+'&sensor=false', null, function (data) {
+        $.getJSON('https://maps.googleapis.com/maps/api/geocode/json?address='+addresses[x]+'&sensor=false', null, function (data) {
             var p = data.results[0].geometry.location
             var latlng = new google.maps.LatLng(p.lat, p.lng);
             new google.maps.Marker({


### PR DESCRIPTION
## Summary
- update the Google Maps API URL to use HTTPS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684be6b174d4832ebd3543d32a4e8de8