### PR TITLE
Add custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Page Not Found</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/png" href="images/logo.png">
+    <link rel="stylesheet" href="css/bootstrap.css">
+    <link rel="stylesheet" href="css/style.css">
+  </head>
+  <body class="text-center">
+    <div class="container">
+      <h1 class="display-4 mt-5">404 - Page Not Found</h1>
+      <p class="lead">Sorry, the page you were looking for doesn't exist.</p>
+      <p><a href="index.html" class="btn btn-primary mt-3">Return Home</a></p>
+    </div>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # marwinwijaya.github.io
 Web CV &amp; Portofolio Muhamad Arwin Wijaya (http://marwinwijaya.github.io)
+
+## 404 Page
+
+A custom `404.html` page provides a friendly message when visitors navigate to an unknown route. GitHub Pages automatically uses this file when present in the repository root.


### PR DESCRIPTION
## Summary
- add a simple 404 page with a link back home
- document the custom 404 page in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f6bf14820832ea941cbcf3b020f50