### PR TITLE
Fix inconsistent h1 sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -34,6 +34,9 @@ h1, h2, h3, h4, h5 {
   color: #2c3e50;
   font-weight: 200;
 }
+h1 {
+  font-size: 2.5rem;
+}
 
 a {
   transition: 0.3s all;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -37,8 +37,11 @@ body {
   color: $white;
 }
 h1, h2,h3,h4, h5 {
-	color: #2c3e50;
-	font-weight: 200;
+        color: #2c3e50;
+        font-weight: 200;
+}
+h1 {
+        font-size: 2.5rem;
 }
 a {
 	transition: .3s all;


### PR DESCRIPTION
## Summary
- set base `font-size` for the global `h1` element so headings keep a consistent size within `<section>` elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fbcc13e4c832eac08274eec3e169a