### PR TITLE
Improve text contrast for accessibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -218,7 +218,7 @@ a:hover, a:focus, a:active {
 .site-hero .site-subheading {
   max-width: 640px;
   margin: 0 auto;
-  color: rgba(255, 255, 255, 0.5);
+  color: #fff;
 }
 
 .site-section {
@@ -718,7 +718,7 @@ a:hover, a:focus, a:active {
 }
 .block-47 .block-47-quote .block-47-quote-author {
   font-size: 14px;
-  color: #666666;
+  color: #333333;
 }
 
 .left {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -270,7 +270,7 @@ a {
   .site-subheading {
     max-width: 640px;
     margin: 0 auto;
-    color: rgba(255, 255, 255, 0.5);
+    color: $white;
   }
 }
 
@@ -803,7 +803,7 @@ a {
 
     .block-47-quote-author {
       font-size: 14px;
-      color: lighten($black, 40%);
+      color: lighten($black, 20%);
     }
   }
 }


### PR DESCRIPTION
## Summary
- update `.site-subheading` text color to white for better contrast
- darken `.block-47-quote-author` text
- rebuild compiled CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850bef9b770832ebb559c7c08e8ad6d