### PR TITLE
Potential fix for code scanning alert no. 3: Exposure of private files

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ const limiter = RateLimit({
 app.use(limiter);
 
 // Serve static files with long cache TTL (1 year)
-app.use(express.static(__dirname, {
+app.use(express.static(path.join(__dirname, 'public'), {
   maxAge: '1y',
   immutable: true
 }));


### PR DESCRIPTION
Potential fix for [https://github.com/marwinwijaya/marwinwijaya.github.io/security/code-scanning/3](https://github.com/marwinwijaya/marwinwijaya.github.io/security/code-scanning/3)

To fix the issue, we should avoid serving the entire root directory (`__dirname`) as static files. Instead, we should create a dedicated folder (e.g., `public`) for static assets and serve only that folder. This ensures that only files explicitly intended for public access are exposed. 

Steps to implement the fix:
1. Create a `public` directory in the project root and move all static files (e.g., HTML, CSS, JavaScript) into it.
2. Update the `express.static` call to serve the `public` directory instead of `__dirname`.
3. Ensure that sensitive files (e.g., `.env`, configuration files) are not placed in the `public` directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
